### PR TITLE
Add Vogen-based and sealed records benchmarks (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,5 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+.idea/

--- a/Benchmarks.cs
+++ b/Benchmarks.cs
@@ -19,12 +19,16 @@ public class Benchmarks
             .ToList();
     }
 
-    
-
     [Benchmark]
     public void RecordId()
     {
         _generatedGuids.ForEach(x => _businessProcess.ProcessProduct(new ProductId(x)));
+    }
+
+    [Benchmark]
+    public void SealedRecordId()
+    {
+        _generatedGuids.ForEach(x => _businessProcess.ProcessLineItem(new LineItemId(x)));
     }
 
     [Benchmark]
@@ -43,5 +47,11 @@ public class Benchmarks
     public void ClassId()
     {
         _generatedGuids.ForEach(x => _businessProcess.ProcessPerson(new PersonId(x)));
+    }
+
+    [Benchmark]
+    public void VogenId()
+    {
+        _generatedGuids.ForEach(x => _businessProcess.ProcessOrder(OrderId.From(x)));
     }
 }

--- a/BusinessProcess.cs
+++ b/BusinessProcess.cs
@@ -6,4 +6,6 @@ public class BusinessProcess
     public ProductId ProcessProduct(ProductId id) => id;
     public CustomerId ProcessCustomer(CustomerId id) => id;
     public PersonId ProcessPerson(PersonId id) => id;
+    public OrderId ProcessOrder(OrderId id) => id;
+    public LineItemId ProcessLineItem(LineItemId id) => id;
 }

--- a/README.md
+++ b/README.md
@@ -4,20 +4,22 @@ This repo shows how we can use various coding constructs to implement Strongly T
 
 Here is a sample run from BenchmarkDotNet:
 
-```
+```text
 // * Summary *
 
-BenchmarkDotNet v0.13.7, Windows 11 (10.0.22631.2129)
-12th Gen Intel Core i9-12900HK, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 8.0.100-preview.6.23330.14
-  [Host]     : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT AVX2
-  DefaultJob : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT AVX2
+BenchmarkDotNet v0.13.7, macOS 15.2 (24C101) [Darwin 24.2.0]
+Apple M4 Pro, 1 CPU, 14 logical and 14 physical cores
+.NET SDK 9.0.100
+  [Host]     : .NET 9.0.0 (9.0.24.52809), Arm64 RyuJIT AdvSIMD
+  DefaultJob : .NET 9.0.0 (9.0.24.52809), Arm64 RyuJIT AdvSIMD
 
 
-|                              Method |     Mean |    Error |   StdDev |    Gen0 | Allocated |
-|------------------------------------ |---------:|---------:|---------:|--------:|----------:|
-|               StructStronglyTypedId | 15.24 us | 0.300 us | 0.334 us |       - |      64 B |
-| ReadonlyRecordStructStronglyTypedId | 15.38 us | 0.294 us | 0.302 us |       - |      64 B |
-|               RecordStronglyTypedId | 31.48 us | 0.628 us | 0.901 us | 25.4517 |  320064 B |
-|                ClassStronglyTypedId | 32.81 us | 0.645 us | 1.096 us | 25.4517 |  320064 B |
+|                 Method |      Mean |     Error |    StdDev |    Gen0 | Allocated |
+|----------------------- |----------:|----------:|----------:|--------:|----------:|
+| ReadonlyRecordStructId |  6.347 us | 0.0150 us | 0.0140 us |  0.0076 |      64 B |
+|               StructId |  6.378 us | 0.0224 us | 0.0209 us |  0.0076 |      64 B |
+|                VogenId |  6.452 us | 0.0161 us | 0.0150 us |  0.0076 |      64 B |
+|               RecordId | 28.931 us | 0.1578 us | 0.1399 us | 38.2385 |  320064 B |
+|         SealedRecordId | 29.340 us | 0.0758 us | 0.0709 us | 38.2385 |  320064 B |
+|                ClassId | 29.952 us | 0.3570 us | 0.3340 us | 38.2385 |  320064 B |
 ```

--- a/StronglyTypedIds.csproj
+++ b/StronglyTypedIds.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.7" />
+    <PackageReference Include="Vogen" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/StronglyTypedIds/LineItemId.cs
+++ b/StronglyTypedIds/LineItemId.cs
@@ -1,0 +1,3 @@
+namespace StronglyTypedIds;
+
+public sealed record LineItemId(Guid Value);

--- a/StronglyTypedIds/OrderId.cs
+++ b/StronglyTypedIds/OrderId.cs
@@ -1,0 +1,6 @@
+using Vogen;
+
+namespace StronglyTypedIds;
+
+[ValueObject<Guid>]
+public readonly partial struct OrderId;


### PR DESCRIPTION
This pull request includes several changes to add new functionality and update the project dependencies. The most important changes include adding new benchmark methods, updating the `BusinessProcess` class, and updating the project target framework and dependencies.

### New functionality:

* [`Benchmarks.cs`](diffhunk://#diff-690ad45674b207c029f0c57525e96d82320c639d06a1d90890f8d28544b8867fL22-R33): Added new benchmark methods `SealedRecordId` and `VogenId` to test additional ID processing scenarios. [[1]](diffhunk://#diff-690ad45674b207c029f0c57525e96d82320c639d06a1d90890f8d28544b8867fL22-R33) [[2]](diffhunk://#diff-690ad45674b207c029f0c57525e96d82320c639d06a1d90890f8d28544b8867fR51-R56)
* [`BusinessProcess.cs`](diffhunk://#diff-816d5e960f386bd055bde26e5f181415cb3398ada1161fdb51663fb8712664adR9-R10): Added methods `ProcessOrder` and `ProcessLineItem` to handle new ID types.
* [`StronglyTypedIds/LineItemId.cs`](diffhunk://#diff-ab872352a4970f0c4b32522eac7bfec7f04638f81eb9c67683f43a1980ca3bcdR1-R3): Added a new sealed record `LineItemId` to represent line item IDs.
* [`StronglyTypedIds/OrderId.cs`](diffhunk://#diff-d1e04dbd2d9c5c2349916415639a7e65fee3c88efd3ec23184fc7f0af2eb8c7fR1-R6): Added a new readonly struct `OrderId` using the `Vogen` library to represent order IDs.

### Project updates:

* [`StronglyTypedIds.csproj`](diffhunk://#diff-968deed87a01b37b6a1b7d5013c11b57c839f02e0fdd22dab12e346bd41a1515L5-R12): Updated target framework to `net9.0` and added a dependency on the `Vogen` library.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R24): Updated benchmark results to reflect the new target framework and added methods.